### PR TITLE
make sure iosPbxProjPath is defined

### DIFF
--- a/scripts/create_ios_strings.js
+++ b/scripts/create_ios_strings.js
@@ -38,6 +38,7 @@ function getTargetIosDir() {
 }
 
 function getXcodePbxProjPath() {
+    initIosDir();
     return iosPbxProjPath;
 }
 


### PR DESCRIPTION
there is a case where writeStringFile is never called before getXcodePbxProjPath which returns undefined, therefore the hook fail silently and cordova prepare too. This commit fixes issue #4