### PR TITLE
Reject the deferral to let cordova know errors

### DIFF
--- a/scripts/create_android_strings.js
+++ b/scripts/create_android_strings.js
@@ -85,7 +85,7 @@ module.exports = function(context) {
             });
         })
         .catch(function(err){
-            throw err;
+            deferred.reject(err);
         });
 
     return deferred.promise;

--- a/scripts/create_ios_strings.js
+++ b/scripts/create_ios_strings.js
@@ -151,6 +151,9 @@ module.exports = function(context) {
                     deferred.resolve();
                 }
             });
+        })
+        .catch(function(err){
+            deferred.reject(err);
         });
 
     return deferred.promise;


### PR DESCRIPTION
If translation json file is malformed, for example,
`cordova build` succeed silently without any actual build process.
This patch fix the case and let the user know the errors.