### PR TITLE
Fix version in plugin.xml to match package.json

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-        id="cordova-plugin-localization-strings" version="1.0.1">
+        id="cordova-plugin-localization-strings" version="1.1.0">
   <name>Localization</name>
   <description>Cordova Plugin for localizing local strings</description>
   <license>MIT License</license>


### PR DESCRIPTION
Fixed the version in `plugin.xml` to match the version published to npm in `package.json`. Version mismatching confuses people, as they install `1.1.0` from npm but `cordova plugin ls` reports `1.0.1`.