### PR TITLE
Fix attempting to add strings for platforms which are not built now

### DIFF
--- a/scripts/create_strings.js
+++ b/scripts/create_strings.js
@@ -15,15 +15,5 @@ module.exports = function(context) {
         promises.push(android_script(context));
     }
 
-    // https://stackoverflow.com/a/43994999/2175025
-    process.on('unhandledRejection', function(reason, p) {
-        console.log('Unhandled Rejection at: Promise', p, 'reason:', reason);
-        // application specific logging, throwing an error, or other logic here
-    });
-    console.log('Listening to promises rejection');
-
-    console.log('Promises');
-    console.log(promises);
-
     return Q.all(promises);
 };

--- a/scripts/create_strings.js
+++ b/scripts/create_strings.js
@@ -3,7 +3,7 @@ var android_script = require('./create_android_strings');
 
 module.exports = function(context) {
     var Q = require('q');
-    var platforms = context.requireCordovaModule('cordova-lib/src/cordova/util').listPlatforms(context.opts.projectRoot);
+    var platforms = context.opts.platforms;
 
     var promises = [];
 
@@ -14,6 +14,16 @@ module.exports = function(context) {
     if (platforms.indexOf('android') >= 0) {
         promises.push(android_script(context));
     }
+
+    // https://stackoverflow.com/a/43994999/2175025
+    process.on('unhandledRejection', function(reason, p) {
+        console.log('Unhandled Rejection at: Promise', p, 'reason:', reason);
+        // application specific logging, throwing an error, or other logic here
+    });
+    console.log('Listening to promises rejection');
+
+    console.log('Promises');
+    console.log(promises);
 
     return Q.all(promises);
 };


### PR DESCRIPTION
I have Android SDK on Windows but the app which I'm building is cross-platform iOS+Android. iOS builds are generated by another machine. My Cordova `config.xml` contains, of course, two platforms.

Currently the plugin (imho) incorrectly handles this case. When I try to `cordova build android` on Windows machine it crashes with `UnhandledPromiseRejectionWarning #<Object>`. This is because the plugin attempts to locate iOS project dir but fails.

This little PR fixes the issue.