### PR TITLE
fix parsing in create_ios_string.js failing when <name> tag has a "short" attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "lodash": "^4.17.2",
     "xcode": "^0.9.0",
     "xml-writer": "^1.6.0",
-    "xml2js": "^0.4.17"
+    "xml2js": "^0.4.17",
+    "xmldom": "^0.1.27"
   },
   "devDependencies": {},
   "license": "MIT",

--- a/scripts/create_ios_strings.js
+++ b/scripts/create_ios_strings.js
@@ -1,18 +1,15 @@
 var fs = require('fs-extra');
 var _ = require('lodash');
 var iconv = require('iconv-lite');
+var xmldom = require('xmldom');
 
 var iosProjFolder;
 var iosPbxProjPath;
 
-var getValue = function(config, name) {
-    var value = config.match(new RegExp('<' + name + '>(.*?)</' + name + '>', "i"));
-    if(value && value[1]) {
-        return value[1]
-    } else {
-        return null
-    }
-};
+var getValue = function(configDoc, name) {
+    var name = configDoc.getElementsByTagName(name)[0];    
+    return name.textContent
+}
 
 function jsonToDotStrings(jsonObj){
     var returnString = "";
@@ -25,7 +22,8 @@ function jsonToDotStrings(jsonObj){
 function initIosDir(){
     if (!iosProjFolder || !iosPbxProjPath) {
         var config = fs.readFileSync("config.xml").toString();
-        var name = getValue(config, "name");
+        var configDoc = (new xmldom.DOMParser()).parseFromString(config, 'application/xml');
+        var name = getValue(configDoc, "name");
 
         iosProjFolder =  "platforms/ios/" + name;
         iosPbxProjPath = "platforms/ios/" + name + ".xcodeproj/project.pbxproj";


### PR DESCRIPTION
This fixes https://github.com/kelvinhokk/cordova-plugin-localization-strings/issues/28

It use xmldom instead of a regex to parse the config.xml file, making sure a valid config.xml should always be parsable even if attributes are added in the future.