### PR TITLE
Changed iOS .strings file encoding to UTF-8.

### DIFF
--- a/scripts/create_ios_strings.js
+++ b/scripts/create_ios_strings.js
@@ -47,7 +47,7 @@ function writeStringFile(plistStringJsonObj, lang, fileName) {
     fs.ensureDir(lProjPath, function (err) {
         if (!err) {
             var stringToWrite = jsonToDotStrings(plistStringJsonObj);
-            var buffer = iconv.encode(stringToWrite, 'utf16');
+            var buffer = iconv.encode(stringToWrite, 'utf8');
 
             fs.open(lProjPath + "/" + fileName, 'w', function(err, fd) {
                 if(err) throw err;


### PR DESCRIPTION
XCode 10 cannot read .strings files in UTF-16, so the encoding was
changed to UTF-8.

Fixes #34.