### PR TITLE
Use different key per platform in json file

### DIFF
--- a/scripts/create_android_strings.js
+++ b/scripts/create_android_strings.js
@@ -165,7 +165,7 @@ function processResult(context, lang, langJson, stringXmlJson) {
         }
     });
 
-    var langJsonToProcess = _.assignIn(langJson.config_android, langJson.app);
+    var langJsonToProcess = _.assignIn(langJson.config_android, langJson.app_android);
 
     //now iterate through langJsonToProcess
     _.forEach(langJsonToProcess, function (val, key) {

--- a/scripts/create_ios_strings.js
+++ b/scripts/create_ios_strings.js
@@ -125,9 +125,9 @@ module.exports = function(context) {
                     }
 
                     //remove APP_NAME and write to Localizable.strings
-                    if (_.has(langJson, "app")) {
+                    if (_.has(langJson, "app_ios")) {
                         //do processing for appname into plist
-                        var localizableStringsJson = langJson.app;
+                        var localizableStringsJson = langJson.app_ios;
                         if (!_.isEmpty(localizableStringsJson)) {
                             writeStringFile(localizableStringsJson, localeLang, "Localizable.strings");
                             localizableStringsPaths.push(localeLang + ".lproj/" + "Localizable.strings");


### PR DESCRIPTION
A quick fix for my issue #37 was to change the .app key to .app_ios and .app_android. 
This way the android xml files are not 'contaminated' with the illegal keys often needed by iOS.

