### PR TITLE
Changes for platform specific app-keys (Issue 37)

### DIFF
--- a/scripts/create_android_strings.js
+++ b/scripts/create_android_strings.js
@@ -212,7 +212,7 @@ function processResult(context, lang, langJson, stringXmlJson) {
         }
     });
 
-    var langJsonToProcess = _.assignIn(langJson.config_android, langJson.app);
+    var langJsonToProcess = _.assignIn(langJson.config_android, langJson.app, langJson.app_android);
 
     //now iterate through langJsonToProcess
     _.forEach(langJsonToProcess, function (val, key) {

--- a/scripts/create_ios_strings.js
+++ b/scripts/create_ios_strings.js
@@ -126,6 +126,12 @@ module.exports = function(context) {
                     if (_.has(langJson, "app")) {
                         //do processing for appname into plist
                         var localizableStringsJson = langJson.app;
+                        
+                        //ios specific strings
+                        if (_.has(langJson, "app_ios")){
+                            Object.assign(localizableStringsJson, langJson.app_ios);
+                        }
+                        
                         if (!_.isEmpty(localizableStringsJson)) {
                             writeStringFile(localizableStringsJson, localeLang, "Localizable.strings");
                             localizableStringsPaths.push(localeLang + ".lproj/" + "Localizable.strings");


### PR DESCRIPTION
This should solve #37 .

The .json files can now contain three .app keys:

- app for translations which are valid for both platforms
- app_ios, app_android specific for each platform.

A platform specific translation should overwrite a general translation, if it exists.

Example:
```
{
    "app": {
        "HAVE_MAIL_TITLE": "Sie haben Post. This should be overwritten by platform-specific string.",
        "HAVE_MAIL_MSG": "%1$@ has you a message titled \\\"%2$@\\\""
    },
    "app_ios": {
        "HAVE_MAIL_TITLE": "Sie haben Post in iOS.",
        "Key with Spaces": "Schlüssel mit Leerzeichen"
    },
    "app_android": {
        "HAVE_MAIL_TITLE": "Sie haben Post in Android.",
        "ONLY_ON_ANDROID": "Testmeldung nur unter Android."
    }
}
```
