### PR TITLE
fix(ios): synchronous hook for xcode.project changes, part 2 (#33)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-localization-strings",
-  "version": "3.2.1",
+  "version": "3.2.1-dev-1.0",
   "description": "Cordova Plugin for handling localization strings on InfoPlist.strings and Localizable.strings on iOS, strings.xml on Android",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-localization-strings",
-  "version": "3.2.1-dev-1.0",
+  "version": "3.2.1-dev-1.1",
   "description": "Cordova Plugin for handling localization strings on InfoPlist.strings and Localizable.strings on iOS, strings.xml on Android",
   "repository": {
     "type": "git",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-        id="cordova-plugin-localization-strings" version="3.2.1-dev-1.0">
+        id="cordova-plugin-localization-strings" version="3.2.1-dev-1.1">
   <name>Localization</name>
   <description>Cordova Plugin for localizing local strings</description>
   <license>MIT License</license>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-        id="cordova-plugin-localization-strings" version="3.2.1">
+        id="cordova-plugin-localization-strings" version="3.2.1-dev-1.0">
   <name>Localization</name>
   <description>Cordova Plugin for localizing local strings</description>
   <license>MIT License</license>

--- a/scripts/create_ios_strings.js
+++ b/scripts/create_ios_strings.js
@@ -138,29 +138,29 @@ module.exports = function(context) {
 
             });
 
-            var proj = xcode.project(getXcodePbxProjPath());
+			// every plugin can change project.pbxproj file,
+			// async operations can be exist with random queue, (promise/callback and etc.)
+			// every part with  xcode.project should be existed only in one task (micro)
 
-            return new Promise(function (resolve, reject) {
-              proj.parse(function (error) {
-                  if (error) {
-                    reject(error);
-                  }
+			var proj = xcode.project(getXcodePbxProjPath());
+			proj.parseSync();
 
-                  writeLocalisationFieldsToXcodeProj(localizableStringsPaths, 'Localizable.strings', proj);
-                  writeLocalisationFieldsToXcodeProj(infoPlistPaths, 'InfoPlist.strings', proj);
+			writeLocalisationFieldsToXcodeProj(localizableStringsPaths, 'Localizable.strings', proj);
+			writeLocalisationFieldsToXcodeProj(infoPlistPaths, 'InfoPlist.strings', proj);
 
-                  fs.writeFileSync(getXcodePbxProjPath(), proj.writeSync());
-                  console.log('new pbx project written with localization groups');
-                  
-                  var platformPath   = path.join( context.opts.projectRoot, "platforms", "ios" );
-                  var projectFileApi = require( path.join( platformPath, "/cordova/lib/projectFile.js" ) );
-                  projectFileApi.purgeProjectFileCache( platformPath );
-                  console.log(platformPath + ' purged from project cache');
-                  
-                  resolve();
-              });
-            });
-        });
+			fs.writeFileSync(getXcodePbxProjPath(), proj.writeSync());
+			console.log('new pbx project written with localization groups');
+
+			var platformPath = path.join(context.opts.projectRoot, 'platforms', 'ios');
+			var projectFileApi = require(path.join(platformPath, '/cordova/lib/projectFile.js'));
+			projectFileApi.purgeProjectFileCache(platformPath);
+			console.log(platformPath + ' purged from project cache');
+
+        })
+		.catch(err => {
+			console.error('localization plugin error: ' + JSON.stringify(err));
+			throw Error(err);
+		});
 };
 
 


### PR DESCRIPTION
every plugin can change project.pbxproj file,
async operations can be exist with random queue, (promise/callback and etc.)
every part with xcode.project should be existed only in one task (micro)
, see https://github.com/kelvinhokk/cordova-plugin-localization-strings/pull/61