### PR TITLE
Android: Get and apply defaultlocale

### DIFF
--- a/scripts/create_android_strings.js
+++ b/scripts/create_android_strings.js
@@ -140,12 +140,19 @@ function getTargetLang(context) {
 
 function getLocalStringXmlPath(context, lang) {
     var resPath = getResPath(context);
-    return path.normalize(path.join(resPath, 'values' + (lang !== 'en' ? '-' + lang : ''), 'strings.xml'));
+    var defaultLocale = getDefaultLocale();
+    return path.normalize(path.join(resPath, 'values' + (lang !== defaultLocale ? '-' + lang : ''), 'strings.xml'));
 }
 
 function getResPath(context) {
     var locations = context.requireCordovaModule('cordova-lib/src/platforms/platforms').getPlatformApi('android').locations;
     return (locations && locations.res) || path.join(context.opts.projectRoot, 'platforms/android/res');
+}
+
+function getDefaultLocale() {
+    var config = fs.readFileSync('config.xml').toString();
+    var matches = config.match(new RegExp('<widget[^>]*?defaultlocale="(.*?)"[\\s\\S]*?>', 'i'));
+    return (matches && matches[1]) || 'en';
 }
 
 // process the modified xml and write to file


### PR DESCRIPTION
To match your Cordova project default strings not in English, this PR adds new behavior:
1. read the value possibly set for the `defaultlocale` attribute on your [`<widget>`](https://cordova.apache.org/docs/en/latest/config_ref/#widget) in _config.xml_ - that Cordova only seems to use for iOS and Windows
1. use it in `getLocalStringXmlPath` instead of the hardcoded `'en'`

Fix #59.