### PR TITLE
Readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Cordova Localization String Plugin
+# Cordova Localization Strings Plugin
 
-This plugin helps you to manage string files that you need natively, namely on Localizable.strings and InfoPlist.strings on iOS, and strings.xml on Android.
+This plugin helps you manage string files that you need natively, namely `Localizable.strings` and `InfoPlist.strings` on iOS, and `strings.xml` on Android.
 
 This plugin also lets you localize your app name on both iOS and Android.
 
@@ -43,9 +43,9 @@ A JSON file may look like this (Note: Breaking change from 1.0.0 onwards - new J
 }
 ```
 
-By default, the language for the Localizable.strings, InfoPlist.strings or strings.xml is taken from the filename.
+By default, the language for the `Localizable.strings`, `InfoPlist.strings` or `strings.xml` is taken from the filename.
 
-For example, if the filename is es.json, the language is hence "es", and the plugin will create "/Resources/es.lproj/Localizable.strings" or "/values-es/strings.xml".
+For example, if the filename is `es.json`, the language is hence `"es"`, and the plugin will create `"/Resources/es.lproj/Localizable.strings"` or `"/values-es/strings.xml"`.
 
 Install iOS or Android platform
 
@@ -55,27 +55,28 @@ Install iOS or Android platform
 Run the code
 
     cordova prepare ios
+    cordova prepare android
 
 #### Platform Specific Localizations
 
 There are some platform specific localizations which differ for Android and iOS, for example for Android:
 
--   zh-rCN
--   zh-rHK
--   zh-rTW
+-   `zh-rCN`
+-   `zh-rHK`
+-   `zh-rTW`
 
 and for iOS:
 
--   zh-Hans
--   zh-Hans-CN
--   zh-Hant
--   zh-Hant-TW
+-   `zh-Hans`
+-   `zh-Hans-CN`
+-   `zh-Hant`
+-   `zh-Hant-TW`
 
-In this case, you can use the locale in the json file to specify the platform localizations as in the following examples.
+In this case, you can add the `"locale"` in the JSON file to specify the platform localizations as in the following examples.
 
-N.B. The "locale" key is optional (if platform localization is not required).
+N.B. The `"locale"` key is optional (if platform localization is not required).
 
-zh-Hans.json
+-   `zh-Hans.json`
 
 ```json
 {
@@ -98,7 +99,7 @@ zh-Hans.json
 }
 ```
 
-zh-Hant.json
+-   `zh-Hant.json`
 
 ```json
 {
@@ -129,13 +130,13 @@ Do remember to install these dependencies too via the `--fetch` when installing 
 
 ## Use Cases
 
-Typically, in a Cordova application, localization is performed on the javascript layer. There are several libraries to help do so like angular-translate on ionic 1 and ngx-translate on ionic 2, with the help of plugins like cordova-plugin-globalization to retrieve the locale or preferred language natively.
+Typically, in a Cordova application, localization is performed on the javascript layer. There are several libraries to help do so like [angular-translate](https://angular-translate.github.io/) on [Ionic 1](https://ionicframework.com/) and [ngx-translate](http://www.ngx-translate.com/) on [Ionic 2+](https://ionicframework.com/), with the help of plugins like [cordova-plugin-globalization](https://github.com/apache/cordova-plugin-globalization) to retrieve the locale or preferred language natively.
 
-This plugin helps in native localization in the following use cases:
+This plugin helps for native localization in the following use cases:
 
 ### Localizing App Name
 
-The plugin will help to localize your app name if you require it to be named differently in different languages. Use the following json file format.
+The plugin will help localize the app name if you require it to be named differently in different languages. Use the following JSON file format.
 
 ```json
 {
@@ -151,7 +152,7 @@ The plugin will help to localize your app name if you require it to be named dif
 
 ### Localizing iOS Permissions
 
-This plugin will help in localize the iOS permission descriptions, for example NSCameraUsageDescription. A full list of iOS permissions and other infoPlist strings that can be found here. (https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html "CocoaKeys")
+This plugin will help localize the iOS permission descriptions, for example `NSCameraUsageDescription`. A full list of iOS permissions and other `InfoPlist` strings that can be found [here](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html).
 
 Example usage:
 
@@ -166,17 +167,17 @@ Example usage:
 
 ### Push notifications messages
 
-Typically, there are 2 main ways push notifications can be localised:
+Typically, there are 2 main ways push notifications can be localized:
 
--   your app saves your user's selected language on the server, and pushes a localised string in the push notification to your user.
--   your server pushes a key to the phone, and the app displays a localised version based on the key in the localization bundle, as determined from the user's phone OS's language.
+-   your app saves your user's selected language on the server, and pushes a localized string in the push notification to your user.
+-   your server pushes a key to the phone, and the app displays a localized version based on the key in the localization bundle, as determined from the user's phone OS's language.
 
 This plugin helps in the latter approach.
 
 More information about the respective string localizations and formatting here:
 
--   Storing Localized Content in Your App Bundle (https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CreatingtheNotificationPayload.html#//apple_ref/doc/uid/TP40008194-CH10-SW9)
--   Formatting strings (https://developer.android.com/guide/topics/resources/string-resource.html#FormattingAndStyling)
+-   [Storing Localized Content in Your App Bundle](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CreatingtheNotificationPayload.html#//apple_ref/doc/uid/TP40008194-CH10-SW9)
+-   [Formatting strings](https://developer.android.com/guide/topics/resources/string-resource.html#FormattingAndStyling)
 
 Example usage:
 
@@ -189,14 +190,14 @@ Example usage:
 }
 ```
 
-The plugin will automatically generate Localizable.strings file using the following entry on iOS:
+The plugin will automatically generate `Localizable.strings` file using the following entry on iOS:
 
 ```
 "HAVE_MAIL_TITLE" = "You have mail.";
 "HAVE_INVITE_MSG" = "%1$@ has invited you to game room %2$@";
 ```
 
-And on Android, the respective locale's strings.xml:
+And on Android, the respective locale's `strings.xml`:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -206,15 +207,15 @@ And on Android, the respective locale's strings.xml:
 </resources>
 ```
 
-## Details (iOS)
+## Details for iOS
 
-The plugin reads the assumed directory structure. The plugin reads from all the fields in config_ios and writes into the InfoPlist.strings, which will be placed in the respective locale.lproj directory. The rest of the strings in "app" will be placed in the Localizable.strings file and placed in the locale directory.
+The plugin reads the assumed directory structure. It then reads from all the fields in `"config_ios"` and writes into the `InfoPlist.strings`, which will be placed in the respective `locale.lproj` directory. The rest of the strings in `"app"` will be placed in the `Localizable.strings` file inside the locale directory.
 
-## Details (Android)
+## Details for Android
 
-The plugin reads the assumed directory structure, the plugin will combine all properties in "config_android" and "app", and inserted into the strings.xml of the locale's /res/val-locale/strings.xml
+The plugin reads the assumed directory structure. It then combines all properties in `"config_android"` and `"app"` to insert them into the `strings.xml` of the locale's `/res/val-locale/strings.xml`.
 
-## Override platform specific translations:
+## Overriding platform specific translations:
 
 ```json
 {
@@ -233,4 +234,4 @@ The plugin reads the assumed directory structure, the plugin will combine all pr
 }
 ```
 
-(if `app_ios` or `app_android` are detected they will be used and override keys from `app`)
+If `"app_ios"` or `"app_android"` are detected, they will be used and override keys from `"app"`.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This plugin also lets you localize your app name on both iOS and Android.
 
 ## How to Use
 
-Install the plugin by fetching the dependencies
+Install the plugin
 
-    $ cordova plugin add cordova-plugin-localization-strings --save
+    $ cordova plugin add cordova-plugin-localization-strings
 
 Modify your project root to have the following structure:
 
@@ -124,9 +124,7 @@ N.B. The `"locale"` key is optional (if platform localization is not required).
 
 ## Dependencies
 
-This plugin relies on node >= 10 for some of its dependencies, and cordova >= 6.1.0.
-
-Do remember to install these dependencies too via the `--fetch` when installing the plugin.
+This plugin works on cordova >= 6.1.0 and node >= 10.
 
 ## Use Cases
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ A JSON file may look like this (Note: Breaking change from 1.0.0 onwards - new J
 
 By default, the language for the `Localizable.strings`, `InfoPlist.strings` or `strings.xml` is taken from the filename.
 
-For example, if the filename is `es.json`, the language is hence `"es"`, and the plugin will create `"/Resources/es.lproj/Localizable.strings"` or `"/values-es/strings.xml"`.
+For example, if the filename is `es.json`, the language is hence `"es"`, and the plugin will create `"/Resources/es.lproj/Localizable.strings"` or `"/res/values-es/strings.xml"`.
 
 Install iOS or Android platform
 
@@ -211,9 +211,9 @@ The plugin reads the assumed directory structure. It then reads from all the fie
 
 ## Details for Android
 
-The plugin reads the assumed directory structure. It then combines all properties in `"config_android"` and `"app"` to insert them into the `strings.xml` of the locale's `/res/val-locale/strings.xml`.
+The plugin reads the assumed directory structure. It then combines all properties in `"config_android"` and `"app"` to insert them into the `strings.xml` of the locale's `/res/values-<xx>/strings.xml`.
 
-Note that for the app's default language the strings are stored in `"/values/strings.xml"` (directory name without `-xx` suffix).
+Note that for the app's default language the strings are stored in `"/res/values/strings.xml"` (directory name without `-<xx>` suffix).
 This plugin considers `'en'` for the default value, matching your `en.json` file if it exists, but to change this you should define your own value through the `defaultlocale` attribute on your [`<widget>`](https://cordova.apache.org/docs/en/latest/config_ref/#widget) in _config.xml_.
 For example `<widget id="" defaultlocale="es">…</widget>`.
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,10 @@ The plugin reads the assumed directory structure. It then reads from all the fie
 
 The plugin reads the assumed directory structure. It then combines all properties in `"config_android"` and `"app"` to insert them into the `strings.xml` of the locale's `/res/val-locale/strings.xml`.
 
+Note that for the app's default language the strings are stored in `"/values/strings.xml"` (directory name without `-xx` suffix).
+This plugin considers `'en'` for the default value, matching your `en.json` file if it exists, but to change this you should define your own value through the `defaultlocale` attribute on your [`<widget>`](https://cordova.apache.org/docs/en/latest/config_ref/#widget) in _config.xml_.
+For example `<widget id="" defaultlocale="es">…</widget>`.
+
 ## Overriding platform specific translations:
 
 ```json


### PR DESCRIPTION
Changes made in Readme file:
- wording, add links and review style to name files and keys
- review How to install and dependencies
Modern install for plugin with dependencies does not require `--save` nor `--fetch` anymore, since Cordova CLI made those the default values.
See comment in PR #67.
- add details about `defaultlocale` for Android
Relates to PR #66.