### PR TITLE
Allow for optional short name notation in config.xml (solves #72)

### DIFF
--- a/scripts/create_ios_strings.js
+++ b/scripts/create_ios_strings.js
@@ -19,6 +19,11 @@ function jsonToDotStrings(jsonObj) {
 function getProjectName() {
     var config = fs.readFileSync('config.xml').toString();
     var matches = config.match(new RegExp('<name>(.*?)</name>', 'i'));
+    
+    // if simple name-tag not found then try optional form of name tag with short name
+    if (!matches)
+        matches = config.match(new RegExp('<name short=".*?">(.*?)</name>', 'i'));
+
     return (matches && matches[1]) || null;
 }
 


### PR DESCRIPTION
If original regexp `<name>` ... does not match, try again with `<name short=""> ...`

The alternative would be of course to do proper XML-Parsing again, but that would be a more complex task and would introduce new dependencies, so I went with this easy addition.