### PR TITLE
Allow to localize settings bundle localizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,24 @@ Example usage:
 }
 ```
 
+### iOS Settings localizations
+
+This plugin can localizae iOS Settings bundles.
+
+Example usage:
+```json
+{
+    "settings_ios": {
+        "Root": {
+            "App version": "App version"
+        }
+    }
+}
+```
+
+In the example shown, it would create a file such as "platforms/ios/<app name>/Resources/Settings.bundle/<language>.lproj/Root.strings" with
+the expected localizations for that language.
+
 ### Push notifications messages
 
 Typically, there are 2 main ways push notifications can be localized:


### PR DESCRIPTION
Can create localizations for the Settings.bundle. For example,
in Spanish (es.json):

  "settings": {
    "Root": {
      "Core Build": "Core Buil",
      "Core Information": "Core Informatio",
      "Group": "Agrupar",
      "Host": "Host",
      "Identifier": "Identificador",
      "Model Build": "Modelo Buil",
      "Model Path": "Modelo Pat",
      "Model Version": "Modelo Versio",
      "Name": "Nombre",
      "Revision": "Revisión",
      "Server Information": "Información del servidor",
      "Version": "Versión"
    }
  }

It will create a file such as

platforms/ios/<app>/Resources/Settings.bundle/es.lproj/Root.strings

with the correct localizations