### PR TITLE
Allow AppShortcuts localization in iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Example usage:
 
 ### iOS Settings localizations
 
-This plugin can localizae iOS Settings bundles.
+This plugin can localize iOS Settings bundles.
 
 Example usage:
 ```json
@@ -180,6 +180,23 @@ Example usage:
 
 In the example shown, it would create a file such as "platforms/ios/<app name>/Resources/Settings.bundle/<language>.lproj/Root.strings" with
 the expected localizations for that language.
+
+### iOS Settings localizations
+
+This plugin can localize iOS AppShortcuts used by Shortcuts app and Siri.
+
+Example usage:
+
+```json
+{
+  "app_shortcuts": {
+    "example_shortcut": "Execute example shortcut of ${applicationName}"
+  }
+}
+```
+
+The Key-Value-Pairs are saved as AppShortcuts.strings in the Resources folder.
+Their value is not modified. Therefor all restrictions for app shortcut phrases apply.
 
 ### Push notifications messages
 

--- a/scripts/create_ios_strings.js
+++ b/scripts/create_ios_strings.js
@@ -81,6 +81,7 @@ module.exports = function (context) {
     var infoPlistPaths = [];
     var localizableStringsPaths = [];
     var settingsBundlePaths = [];
+    var appShortcutsPaths = [];
 
     return getTargetLang(context).then(function (languages) {
         languages.forEach(function (lang) {
@@ -124,6 +125,11 @@ module.exports = function (context) {
                         localizableStringsPaths.push(localeLang + '.lproj/' + 'Localizable.strings');
                     }
                 }
+
+                if (_.has(langJson, 'app_shortcuts') && !_.isEmpty(langJson.app_shortcuts)) {
+                    writeStringFile(langJson.app_shortcuts, localeLang, 'AppShortcuts.strings');
+                    appShortcutsPaths.push(localeLang + '.lproj/' + 'AppShortcuts.strings');
+                }
                     
                 // to create Settings.bundle localizations
                 if (_.has(langJson, "settings_ios")) {
@@ -154,6 +160,7 @@ module.exports = function (context) {
 
                 writeLocalisationFieldsToXcodeProj(infoPlistPaths, 'InfoPlist.strings', proj);
                 writeLocalisationFieldsToXcodeProj(localizableStringsPaths, 'Localizable.strings', proj);
+                writeLocalisationFieldsToXcodeProj(appShortcutsPaths, 'AppShortcuts.strings', proj);
 
                 fs.writeFileSync(pbxProjPath, proj.writeSync());
                 console.log('Pbx project written with localization groups', _.map(languages, 'lang'));


### PR DESCRIPTION
Localizations for app shortcut phrases for use in Shortcuts app and with Siri are required to be located in AppShortcuts.strings. This PR extends create_ios_strings to look for the key 'app-shortcuts' and create that file with its contents.