### PR TITLE
use posix true to force windows to use / as path separator

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -44,7 +44,7 @@ module.exports = {
 		}
 		return new Promise(function (resolve, reject) {
 			// TODO: reject promise ?
-			glob(providedTranslationPathPattern).forEach(function (langFile) {
+			glob(providedTranslationPathPattern, {posix: true}).forEach(function (langFile) {
 				var matches = langFile.match(providedTranslationPathRegex);
 				if (matches) {
 					targetLangArr.push({


### PR DESCRIPTION
This fixes issue #83 

Issue:
Since version 5.0.0 of this plugin, the regex used to get the language from the json files to then create the strings.xml files was not working. This was due to the update of the `glob` dependency (now 10.2.1) which has had some changes regarding forward and back slashes since the previously used version (7.2.0).

Fix:
This broken regex issue (which causes this plugin to not work at all on Windows) is easily resolved by using a newly added `glob` option `posix: true`, which forces it to return `/` delimited paths on Windows instead of `\`, which matches the expected regex already in the repo.

